### PR TITLE
Fix Dotnet version

### DIFF
--- a/templates/init_restore.yml
+++ b/templates/init_restore.yml
@@ -2,6 +2,10 @@ parameters:
   solutionPath: ''
 
 steps:
+- task: UseDotNet@2
+  inputs:
+    packageType: 'sdk'
+    version: '2.2.100'
 - task: NuGetToolInstaller@1
 - task: NuGetCommand@2
   inputs:


### PR DESCRIPTION
Using the example pipeline from this branch will give the following error: `##[error]/Users/runner/.dotnet/sdk/2.1.507/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets(137,5): Error NETSDK1045: The current .NET SDK does not support targeting .NET Core 2.2.  Either target .NET Core 2.1 or lower, or use a version of the .NET SDK that supports .NET Core 2.2.
`
You need to manually specify the dotnet core version you want to use. Here I used 2.2.100 but you can find a complete list of supported versions here: https://github.com/dotnet/core/blob/master/release-notes/releases-index.json

This little task will make everything work again.
